### PR TITLE
gui2d: add fit bounds, cancellable background fitting, window cleanup

### DIFF
--- a/src/gui2d/experiments.jl
+++ b/src/gui2d/experiments.jl
@@ -72,8 +72,10 @@ function setupexptobservables!(expt)
     expt.yradius[] = clamp(4 * yres, 0.1, 0.8)
     on(expt.peaks) do _
         @debug "Peaks changed"
-        # invalidate any in-flight fit - peaks have been added/moved/deleted
-        expt.state[][:fit_generation][] += 1
+        # N.B. do NOT bump :fit_generation here - this observer also fires on the
+        # fit's own completion notify(expt.peaks). Genuine user changes reach
+        # fit!(expt) (via the touched chain), which bumps the generation itself and
+        # supersedes any in-flight fit.
         mask!(expt)
         cluster!(expt)
         return simulate!(expt)
@@ -101,15 +103,16 @@ function setupexptobservables!(expt)
         if expt.isfitting[]
             fit!(expt)
         else
-            # fitting toggled off - cancel any in-flight fit
+            # fitting toggled off - cancel any in-flight fit (this bypasses fit!,
+            # so bump the generation and clear the fitting status ourselves)
             expt.state[][:fit_generation][] += 1
+            expt.state[][:mode][] = :normal
         end
     end
     on(expt.xradius) do _
         @debug "X radius changed"
-        # invalidate any in-flight fit - bounds/mask have changed
-        expt.state[][:fit_generation][] += 1
-        # update xradius for all peaks
+        # update xradius for all peaks (notify reaches fit!, which supersedes any
+        # in-flight fit)
         for peak in expt.peaks[]
             peak.xradius.val = expt.xradius[]
             peak.touched.val = true
@@ -118,9 +121,8 @@ function setupexptobservables!(expt)
     end
     on(expt.yradius) do _
         @debug "Y radius changed"
-        # invalidate any in-flight fit - bounds/mask have changed
-        expt.state[][:fit_generation][] += 1
-        # update yradius for all peaks
+        # update yradius for all peaks (notify reaches fit!, which supersedes any
+        # in-flight fit)
         for peak in expt.peaks[]
             peak.yradius.val = expt.yradius[]
             peak.touched.val = true

--- a/src/gui2d/experiments.jl
+++ b/src/gui2d/experiments.jl
@@ -38,6 +38,16 @@ include("expt-ccr.jl")
 
 # generic functions
 
+"""Maximum wall-clock time (seconds) allowed for a single cluster fit before it is aborted.
+
+Interactive fitting re-runs on every peak move, so a hard cap keeps the GUI responsive even
+if convergence is slow. The residual function checks elapsed time on every iteration."""
+const FIT_TIME_BUDGET = 5.0
+
+"""Thrown from within a fit's residual function to abort an in-flight fit (because the inputs
+changed, the time budget was exceeded, or the user cancelled). Caught silently in `fit!(expt)`."""
+struct FitCancelled <: Exception end
+
 """
     nslices(expt::Experiment)
 
@@ -62,6 +72,8 @@ function setupexptobservables!(expt)
     expt.yradius[] = clamp(4 * yres, 0.1, 0.8)
     on(expt.peaks) do _
         @debug "Peaks changed"
+        # invalidate any in-flight fit - peaks have been added/moved/deleted
+        expt.state[][:fit_generation][] += 1
         mask!(expt)
         cluster!(expt)
         return simulate!(expt)
@@ -88,10 +100,15 @@ function setupexptobservables!(expt)
         @debug "Fitting changed"
         if expt.isfitting[]
             fit!(expt)
+        else
+            # fitting toggled off - cancel any in-flight fit
+            expt.state[][:fit_generation][] += 1
         end
     end
     on(expt.xradius) do _
         @debug "X radius changed"
+        # invalidate any in-flight fit - bounds/mask have changed
+        expt.state[][:fit_generation][] += 1
         # update xradius for all peaks
         for peak in expt.peaks[]
             peak.xradius.val = expt.xradius[]
@@ -101,6 +118,8 @@ function setupexptobservables!(expt)
     end
     on(expt.yradius) do _
         @debug "Y radius changed"
+        # invalidate any in-flight fit - bounds/mask have changed
+        expt.state[][:fit_generation][] += 1
         # update yradius for all peaks
         for peak in expt.peaks[]
             peak.yradius.val = expt.yradius[]
@@ -189,26 +208,52 @@ function fit!(expt::Experiment)
     end
     anythingchanged || return
 
-    @async begin
-        expt.state[][:mode][] = :fitting
-        sleep(0.1) # allow time for mode change to be processed
-    end
-    @async begin # do fitting in a separate task
-        sleep(0.1) # allow time for mode change to be processed
-        # iterate over touched clusters and fit
-        for i in 1:length(expt.clusters[])
-            if expt.touched[][i]
-                fit!(expt.clusters[][i], expt)
-                postfit!(expt.clusters[][i], expt)
+    # Bump the fit generation. This supersedes any fit already running: that task's residual
+    # function will see the new generation on its next iteration and abort via FitCancelled,
+    # and its results will not be committed (the notify below is generation-guarded).
+    mygen = (expt.state[][:fit_generation][] += 1)
+
+    # Run the fit off the GUI's critical path. With multiple threads we use a real background
+    # thread (Threads.@spawn) so the GUI stays fully responsive; single-threaded we fall back to
+    # @async, relying on the yield() inside the residual to give the event loop cycles so the fit
+    # can still be cancelled. The fitting code only writes peak parameter arrays in place (without
+    # notify), so the only visible update is the generation-guarded notify(expt.peaks) at the end.
+    runfit = function ()
+        try
+            expt.state[][:mode][] = :fitting
+            t0 = time()
+            # iterate over touched clusters and fit
+            for i in 1:length(expt.clusters[])
+                if expt.touched[][i]
+                    fit!(expt.clusters[][i], expt, mygen, t0)
+                    postfit!(expt.clusters[][i], expt)
+                end
+            end
+            postfitglobal!(expt)
+            @debug "Fit finished - notifying peaks" #maxlog=10
+            # Only commit results if this fit is still the current one - a superseded fit must
+            # not push stale results to the display.
+            if expt.state[][:fit_generation][] == mygen
+                notify(expt.peaks)
+            end
+        catch e
+            e isa FitCancelled || rethrow()
+            @debug "Fit cancelled (generation $mygen superseded)"
+        finally
+            # Reset the status background only if we are still the current fit; a newer fit will
+            # manage its own mode. Guarantees the mode resets even on cancellation/error.
+            if expt.state[][:fit_generation][] == mygen
+                expt.state[][:mode][] = :normal
             end
         end
-
-        postfitglobal!(expt)
-        @debug "Fit finished - notifying peaks" #maxlog=10
-        notify(expt.peaks)
-
-        expt.state[][:mode][] = :normal
     end
+
+    if Threads.nthreads() > 1
+        expt.state[][:fit_task][] = Threads.@spawn runfit()
+    else
+        expt.state[][:fit_task][] = @async runfit()
+    end
+    return expt.state[][:fit_task][]
 end
 
 # placeholder functions for additional fitting following spectrum fit
@@ -227,7 +272,8 @@ end
 """Global fitting of entire experiment following spectrum fit - defaults to no action"""
 postfitglobal!(expt::Experiment) = nothing
 
-function fit!(cluster::Vector{Int}, expt::Experiment)
+function fit!(cluster::Vector{Int}, expt::Experiment, mygen=expt.state[][:fit_generation][],
+              t0=time())
     @debug "Fitting cluster $cluster" #maxlog=10
     peaks = [expt.peaks[][i] for i in cluster]
 
@@ -235,6 +281,8 @@ function fit!(cluster::Vector{Int}, expt::Experiment)
     p0 = pack(peaks, :initial)
     pmin = pack(peaks, :min)
     pmax = pack(peaks, :max)
+    # lmfit (levenberg_marquardt) throws if p0 lies outside the bounds, so clamp first
+    p0 = clamp.(p0, pmin, pmax)
 
     # get mask and bounds
     m = mask(cluster, expt)
@@ -254,6 +302,14 @@ function fit!(cluster::Vector{Int}, expt::Experiment)
     # create residual function
     function resid(p)
         @debug "resid (start)" maxlog = 10
+        # Abort if this fit has been superseded (peaks/radii changed, fitting toggled off, or
+        # window closed) or if it has exceeded its time budget. The residual is evaluated every
+        # LM iteration, so it is the natural place to hook cancellation.
+        (expt.state[][:fit_generation][] != mygen) && throw(FitCancelled())
+        (time() - t0 > FIT_TIME_BUDGET) && throw(FitCancelled())
+        # Single-threaded: yield so the GUI event loop gets a chance to run (and register a
+        # cancellation) between iterations. Harmless under multithreading.
+        Threads.nthreads() == 1 && yield()
         unpack!(copy(p), peaks, :value)
         for i in 1:nslices(expt)
             fill!(zsim[i], 0.0)
@@ -263,7 +319,15 @@ function fit!(cluster::Vector{Int}, expt::Experiment)
         return zobs - zsimm
     end
     @debug "running fit" maxlog = 10
-    sol = LsqFit.lmfit(resid, p0, Float64[])
+    # Box-constrained, runtime-bounded fit. Bounds keep peak positions within their radius and
+    # R2 within sensible limits. Loose tolerances + maxIter are appropriate for interactive
+    # re-fitting; :finite (the default) matches the Float64-routed residual - a ForwardDiff
+    # Jacobian would be identically zero here. The wall-clock cap is enforced inside `resid` via
+    # FIT_TIME_BUDGET.
+    sol = LsqFit.lmfit(resid, p0, Float64[];
+                       lower=pmin, upper=pmax,
+                       autodiff=:finite,
+                       maxIter=50, x_tol=1e-4, g_tol=1e-6)
     pfit = coef(sol)
     perr = stderror(sol)
     @debug "fit complete" pfit maxlog = 10

--- a/src/gui2d/gui.jl
+++ b/src/gui2d/gui.jl
@@ -230,6 +230,20 @@ function addhanders!(g, state, expt::FixedPeakExperiment)
     on(events(g[:fig]).unicode_input) do character
         return process_unicode_input(expt, state, character)
     end
+
+    # window cleanup on close. window_open fires `false` when the window is closed; without
+    # explicit cleanup GLMakie can leave an invisible window frame behind (notably on macOS),
+    # which otherwise requires a manual GLMakie.closeall(). We also cancel any in-flight fit so a
+    # background task isn't left writing into a closed window's state.
+    on(events(g[:fig].scene).window_open) do isopen
+        isopen && return
+        @debug "Window closed - cleaning up"
+        state[:fit_generation][] += 1
+        # closeall() clears the ghost frame. The app shows one GUI at a time, so closing all
+        # GLMakie windows here is acceptable; switch to a targeted screen close if multiple
+        # simultaneous windows are ever needed.
+        return GLMakie.closeall()
+    end
 end
 
 function renamepeak!(expt, state, initiator)

--- a/src/gui2d/gui.jl
+++ b/src/gui2d/gui.jl
@@ -242,7 +242,16 @@ function addhanders!(g, state, expt::FixedPeakExperiment)
         # closeall() clears the ghost frame. The app shows one GUI at a time, so closing all
         # GLMakie windows here is acceptable; switch to a targeted screen close if multiple
         # simultaneous windows are ever needed.
-        return GLMakie.closeall()
+        #
+        # This observer fires from inside the renderloop's poll cycle, so calling closeall()
+        # synchronously tears down the GL context while the renderloop is still running it
+        # ("Context is not alive anymore!"). Defer it to a separate task (as a manual REPL
+        # closeall() would be) and let the closing window's own teardown settle first.
+        @async begin
+            sleep(0.2)
+            GLMakie.closeall()
+        end
+        return
     end
 end
 

--- a/src/gui2d/keyboard.jl
+++ b/src/gui2d/keyboard.jl
@@ -56,6 +56,14 @@ function process_keyboardbutton(expt, state, event)
             return (Consume())
         end
         return Consume(false)
+    elseif state[:mode][] == :fitting
+        if event.action == Keyboard.press && event.key == Keyboard.escape
+            # cancel the in-flight fit - the running fit's residual will see the bumped
+            # generation and abort
+            state[:fit_generation][] += 1
+            return Consume()
+        end
+        return Consume(false)
     end
 end
 

--- a/src/gui2d/keyboard.jl
+++ b/src/gui2d/keyboard.jl
@@ -59,8 +59,10 @@ function process_keyboardbutton(expt, state, event)
     elseif state[:mode][] == :fitting
         if event.action == Keyboard.press && event.key == Keyboard.escape
             # cancel the in-flight fit - the running fit's residual will see the bumped
-            # generation and abort
+            # generation and abort. No new fit will run, so clear the fitting status
+            # here to restore the UI to :normal.
             state[:fit_generation][] += 1
+            state[:mode][] = :normal
             return Consume()
         end
         return Consume(false)

--- a/src/gui2d/state.jl
+++ b/src/gui2d/state.jl
@@ -4,6 +4,12 @@ function preparestate(expt::Experiment)
 
     state[:mode] = Observable(:normal) # options = :normal, :renaming, :renamingstart, :moving, :fitting
 
+    # Background-fit control. :fit_generation is bumped whenever the fit inputs change (peaks,
+    # radii, fitting toggled off, window closed); an in-flight fit checks it and aborts if it no
+    # longer matches the generation it started with. :fit_task holds the current fit task.
+    state[:fit_generation] = Observable(0)
+    state[:fit_task] = Observable{Union{Task,Nothing}}(nothing)
+
     state[:total_peaks] = Observable(length(expt.peaks[]))
 
     state[:current_slice] = Observable(1)


### PR DESCRIPTION
Resolve three GUI2D fitting issues:

- Enforce parameter bounds: pass the already-computed pmin/pmax to
  LsqFit.lmfit as lower/upper so peak positions stay within their radius
  and R2 stays in range. Clamp p0 into bounds first (lmfit errors
  otherwise) and use finite-difference Jacobians explicitly.

- Bounded, cancellable fitting to stop the GUI freezing: cap each fit
  with loose tolerances, maxIter and a wall-clock budget checked inside
  the residual. Run the fit on a real background thread when Julia is
  multithreaded (falling back to @async + yield otherwise) and use a
  generation token (in expt.state) to abort an in-flight fit whenever
  peaks/radii change, fitting is toggled off, Escape is pressed, or the
  window closes. Superseded fits never commit results.

- Clean up on window close: a window_open handler cancels any running
  fit and calls GLMakie.closeall() to clear the invisible window frame
  left behind on macOS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019aHJQF3343W81nrzkNpBvG